### PR TITLE
Corrigindo falha na propriedade valor do Orcamento, pois quando imple…

### DIFF
--- a/src/Orcamento.php
+++ b/src/Orcamento.php
@@ -9,6 +9,7 @@ class Orcamento implements Orcavel
 {
     private array $itens;
     public EstadoOrcamento $estadoAtual;
+    public float $valor;
 
     public function __construct()
     {
@@ -43,10 +44,12 @@ class Orcamento implements Orcavel
 
     public function valor(): float
     {
-        return array_reduce(
+        $this->valor = array_reduce(
             $this->itens,
             fn (float $valorAcumulado, Orcavel $item) => $item->valor() + $valorAcumulado,
             0
         );
+
+        return $this->valor;
     }
 }


### PR DESCRIPTION
…mentamos o padrão composite acabou que o atributo valor que era utilizado em outros métodos não foi refeito e ficou vago. Um exempo é o método calculaDescontoExtra que necessita deste atriuto juntamente com as classes de EstadoOrcamento que também necessitam deste atributo... foi feita a seguinte alteração: No método Valor() da classe orçamento, ao invés de apenas retornarmos o calculo inteiro, primeiro ela define o valor e eu sei que poderia ser separado em dois métodos, porém achei mais viável desta forma, que ao mesmo tempo que seta o valor, retorna ele ao código cliente (fez mais sentido pra mim desta forma)