### PR TITLE
FIX: Corrigindo classe Orcamento

### DIFF
--- a/src/Descontos/DescontoMaisDe500Reais.php
+++ b/src/Descontos/DescontoMaisDe500Reais.php
@@ -8,8 +8,9 @@ class DescontoMaisDe500Reais extends Desconto
 {
     public function calculaDesconto(Orcamento $orcamento): float
     {
-        if ($orcamento->valor() > 500) {
-            return $orcamento->valor() * 0.05;
+        $valorOrcamento = $orcamento->valor();
+        if ($valorOrcamento > 500) {
+            return $valorOrcamento * 0.05;
         }
 
         return $this->proximoDesconto->calculaDesconto($orcamento);

--- a/src/Descontos/DescontoMaisDe500Reais.php
+++ b/src/Descontos/DescontoMaisDe500Reais.php
@@ -8,8 +8,8 @@ class DescontoMaisDe500Reais extends Desconto
 {
     public function calculaDesconto(Orcamento $orcamento): float
     {
-        if ($orcamento->valor > 500) {
-            return $orcamento->valor * 0.05;
+        if ($orcamento->valor() > 500) {
+            return $orcamento->valor() * 0.05;
         }
 
         return $this->proximoDesconto->calculaDesconto($orcamento);

--- a/src/Descontos/DescontoMaisDe5Itens.php
+++ b/src/Descontos/DescontoMaisDe5Itens.php
@@ -9,7 +9,7 @@ class DescontoMaisDe5Itens extends Desconto
     public function calculaDesconto(Orcamento $orcamento): float
     {
         if ($orcamento->quantidadeItens > 5) {
-            return $orcamento->valor * 0.1;
+            return $orcamento->valor() * 0.1;
         }
 
         return $this->proximoDesconto->calculaDesconto($orcamento);

--- a/src/EstadosOrcamento/Aprovado.php
+++ b/src/EstadosOrcamento/Aprovado.php
@@ -8,7 +8,7 @@ class Aprovado extends EstadoOrcamento
 {
     public function calculaDescontoExtra(Orcamento $orcamento): float
     {
-        return $orcamento->valor * 0.02;
+        return $orcamento->valor() * 0.02;
     }
 
     public function finaliza(Orcamento $orcamento)

--- a/src/EstadosOrcamento/EmAprovacao.php
+++ b/src/EstadosOrcamento/EmAprovacao.php
@@ -8,7 +8,7 @@ class EmAprovacao extends EstadoOrcamento
 {
     public function calculaDescontoExtra(Orcamento $orcamento): float
     {
-        return $orcamento->valor * 0.05;
+        return $orcamento->valor() * 0.05;
     }
 
     public function aprova(Orcamento $orcamento)

--- a/src/Impostos/Icms.php
+++ b/src/Impostos/Icms.php
@@ -8,6 +8,6 @@ class Icms extends Imposto
 {
     public function realizaCalculoEspecifico(Orcamento $orcamento): float
     {
-        return $orcamento->valor * 0.1;
+        return $orcamento->valor() * 0.1;
     }
 }

--- a/src/Impostos/Icpp.php
+++ b/src/Impostos/Icpp.php
@@ -8,16 +8,16 @@ class Icpp extends ImpostoCom2Aliquotas
 {
     protected function deveAplicarTaxaMaxima(Orcamento $orcamento): bool
     {
-        return $orcamento->valor > 500;
+        return $orcamento->valor() > 500;
     }
 
     protected function calculaTaxaMaxima(Orcamento $orcamento): float
     {
-        return $orcamento->valor * 0.03;
+        return $orcamento->valor() * 0.03;
     }
 
     protected function calculaTaxaMinima(Orcamento $orcamento): float
     {
-        return $orcamento->valor * 0.02;
+        return $orcamento->valor() * 0.02;
     }
 }

--- a/src/Impostos/Ikcv.php
+++ b/src/Impostos/Ikcv.php
@@ -8,16 +8,16 @@ class Ikcv extends ImpostoCom2Aliquotas
 {
     protected function deveAplicarTaxaMaxima(Orcamento $orcamento): bool
     {
-        return $orcamento->valor > 300 && $orcamento->quantidadeItens > 3;
+        return $orcamento->valor() > 300 && $orcamento->quantidadeItens > 3;
     }
 
     protected function calculaTaxaMaxima(Orcamento $orcamento): float
     {
-        return $orcamento->valor * 0.04;
+        return $orcamento->valor() * 0.04;
     }
 
     protected function calculaTaxaMinima(Orcamento $orcamento): float
     {
-        return $orcamento->valor * 0.025;
+        return $orcamento->valor() * 0.025;
     }
 }

--- a/src/Impostos/Iss.php
+++ b/src/Impostos/Iss.php
@@ -8,6 +8,6 @@ class Iss extends Imposto
 {
     public function realizaCalculoEspecifico(Orcamento $orcamento): float
     {
-        return $orcamento->valor * 0.06;
+        return $orcamento->valor() * 0.06;
     }
 }

--- a/src/Orcamento.php
+++ b/src/Orcamento.php
@@ -18,7 +18,7 @@ class Orcamento implements Orcavel
 
     public function aplicaDescontoExtra()
     {
-        $this->valor -= $this->estadoAtual->calculaDescontoExtra($this);
+        return $this->estadoAtual->calculaDescontoExtra($this);
     }
 
     public function aprova()

--- a/teste-aplicar-desconto-extra.php
+++ b/teste-aplicar-desconto-extra.php
@@ -1,0 +1,17 @@
+<?php
+
+use Alura\DesignPattern\ItemOrcamento;
+use Alura\DesignPattern\Orcamento;
+
+require_once "vendor/autoload.php";
+
+$orcamento = new Orcamento();
+
+$item1 = new ItemOrcamento();
+$item1->valor = 1000;
+
+$orcamento->addItem($item1);
+$orcamento->aprova();
+
+echo $orcamento->aplicaDescontoExtra();
+


### PR DESCRIPTION
Descricao: Com o passar do tempo e com novos padrões de projeto sendo
implementados, a classe Orcamento sofreu uma alteração que gerou uma
falha no sistema. Antes ela possuia um atributo "valor", porém com
as novas alterações a classe Orcamento passou a receber Objetos do
tipo ItensOrcamento que possuiam o atriuto valor e com isso criamos o
metodo Orcamento->valor() que calculava o valor de todos os itens daquele
orçamento.

Problema: Esse atributo Orcamento->valor ainda era utilizado em diversas
classes do sistema, o que provocaria uma falha grave, pois não existe
mais esse atributo.

Solução: todas as classes que utilizavam o atributo valor do Orcamento
foram alteradas para utilizar o método Orcamento->valor().

OBS: o método Orcamento->aplicarDescontoExtra() foi alterado para que
retornasse o valor do desconto baseado no valor do orçamento.
Antes este método apenas setava o atributo valor que não existe mais.

OBS: foi criado um arquivo de teste para verificar se tudo está se
comportando como deveria (teste-aplicar-desconto-extra.php)